### PR TITLE
[worthent-foundation v1.0.1] State Table Enhancements

### DIFF
--- a/doc/state/state.md
+++ b/doc/state/state.md
@@ -159,7 +159,7 @@ public class TurnstileData extends AbstractStateTableData {
 
     /** Construct in initial state */
     public TurnstileData() {
-        super(TurnstileStates.OFF.name(), TurnstileStates.OFF.name());
+        super(TurnstileStates.OFF, TurnstileStates.OFF);
         turnCount = 0;
         ticketCount = 0;
     }
@@ -182,9 +182,9 @@ public class TurnstileData extends AbstractStateTableData {
     @Actor(name = INCREMENT_COUNT)
     public void increment(final TransitionContext<TurnstileData, StateEvent> context) {
         final String eventName = context.getEvent().getName();
-        if (TurnstileEventType.PUSH.name().equals(eventName)) {
+        if (TurnstileEventType.PUSH.equals(eventName)) {
             turnCount++;
-        } else if (TurnstileEventType.TICKET.name().equals(eventName)) {
+        } else if (TurnstileEventType.TICKET.equals(eventName)) {
             ticketCount++;
         }
     }
@@ -327,26 +327,26 @@ private final StateTable<TurnstileData, StateEvent> turnstileStateTable =
         .withStateTableDefinition()
             .setName("Turnstile")
             .usingActorsInClass(TurnstileData.class)
-            .withState(TurnstileStates.OFF.name())
-                .transitionOnEvent(TurnstileEventType.ON.name()).toState(TurnstileStates.LOCKED.name()).endTransition()
+            .withState(TurnstileStates.OFF)
+                .transitionOnEvent(TurnstileEventType.ON).toState(TurnstileStates.LOCKED).endTransition()
                 .withDefaultEventHandler().toState(StateDef.STAY_IN_STATE).endTransition()
                 .endState()
-            .withState(TurnstileStates.LOCKED.name())
-                .transitionOnEvent(TurnstileEventType.TICKET.name())
-                    .toState(TurnstileStates.UNLOCKED.name())
+            .withState(TurnstileStates.LOCKED)
+                .transitionOnEvent(TurnstileEventType.TICKET)
+                    .toState(TurnstileStates.UNLOCKED)
                     .withActorsByName(TurnstileData.INCREMENT_COUNT)
                     .endTransition()
-                .transitionOnEvent(TurnstileEventType.PUSH.name()).toState(StateDef.STAY_IN_STATE).endTransition()
-                .transitionOnEvent(TurnstileEventType.OFF.name()).toState(TurnstileStates.OFF.name()).endTransition()
+                .transitionOnEvent(TurnstileEventType.PUSH).toState(StateDef.STAY_IN_STATE).endTransition()
+                .transitionOnEvent(TurnstileEventType.OFF).toState(TurnstileStates.OFF).endTransition()
                 .withDefaultEventHandler(StateTransitionDefs.getUnexpectedEventDefaultTransition())
                 .endState()
-            .withState(TurnstileStates.UNLOCKED.name())
-                .transitionOnEvent(TurnstileEventType.TICKET.name()).toState(StateDef.STAY_IN_STATE).endTransition()
-                .transitionOnEvent(TurnstileEventType.PUSH.name())
-                    .toState(TurnstileStates.LOCKED.name())
+            .withState(TurnstileStates.UNLOCKED)
+                .transitionOnEvent(TurnstileEventType.TICKET).toState(StateDef.STAY_IN_STATE).endTransition()
+                .transitionOnEvent(TurnstileEventType.PUSH)
+                    .toState(TurnstileStates.LOCKED)
                     .withActorsByName(TurnstileData.INCREMENT_COUNT)
                     .endTransition()
-                .transitionOnEvent(TurnstileEventType.OFF.name()).toState(TurnstileStates.OFF.name()).endTransition()
+                .transitionOnEvent(TurnstileEventType.OFF).toState(TurnstileStates.OFF).endTransition()
                 .withDefaultEventHandler(StateTransitionDefs.getUnexpectedEventDefaultTransition())
                 .endState()
             .endDefinition()
@@ -421,8 +421,8 @@ You can see that the `StateTableControl` object takes a generic argument to spec
 There are (or will be) multiple implementations of the `StateTableControl` that differ primarily by their threading models:
 
 * `SerialStateTableControl`: This is a thread-unsafe implementation that is meant to be constructed and used within the processing of some high-level request all in the same thread.  It does not start a thread.  Any exceptions thrown during the state table execution propagate up through the method that signals the event.  This is a good candidate for more real-time processing and for parsers.
-* `SingleThreadConsumerStateTableControl` (not yet implemented in v1.0): This implementation is thread safe and directs all events to a queue that is consumed by a single thread that feeds the events to the state table in the order received (with the exception of events submitted by an actor).  This version is good for processing transactional events where order is important but throughput is less important.
-* `MultiThreadedConsumerStateTableControl` (not yet implemented in v1.0): This implementation is thread safe and uses a hash algorithm to dispatch a value from the event (a data ID) to one of multiple queues each of which have their own thread consuming events and feeding them into the state table.  This provides a higher throughput capacity while preserving the order for events with the same data ID.
+* `SingleThreadConsumerStateTableControl` (implemented in v1.0.1): This implementation is thread safe and directs all events to a queue that is consumed by a single thread that feeds the events to the state table in the order received (with the exception of events submitted by an actor).  This version is good for processing transactional events where order is important but throughput is less important.
+* `MultiThreadedConsumerStateTableControl` (not yet implemented as of v1.0.1): This implementation is thread safe and uses a hash algorithm to dispatch a value from the event (a data ID) to one of multiple queues each of which have their own thread consuming events and feeding them into the state table.  This provides a higher throughput capacity while preserving the order for events with the same data ID.
 
 The `SerialStateTableControl` objects invokes the initializer on the State Table Data Manager.
 
@@ -799,16 +799,16 @@ public class XmlObjectBuilderAdapter implements StateTableControl<XmlEvent> {
                 .withStateTableDefinition()
                 .setName("XMLObjectBuilderAdapter")
                 .usingActorsInClass(XmlData.class)
-                .withState(XmlObjectStates.AWAITING_DOCUMENT.name())
+                .withState(XmlObjectStates.AWAITING_DOCUMENT)
                     .transitionOnEvent(SaxEventAdapter.START_DOCUMENT)
-                        .toState(XmlObjectStates.AWAITING_OBJECT_ELEMENT_START.name())
+                        .toState(XmlObjectStates.AWAITING_OBJECT_ELEMENT_START)
                         .withActorsByName(XmlData.PROCESS_DOCUMENT_START)
                         .endTransition()
                     .withDefaultEventHandler(StateTransitionDefs.getUnexpectedEventDefaultTransition())
                     .endState()
-                .withState(XmlObjectStates.AWAITING_OBJECT_ELEMENT_START.name())
+                .withState(XmlObjectStates.AWAITING_OBJECT_ELEMENT_START)
                     .transitionOnEvent(SaxEventAdapter.START_ELEMENT)
-                        .toState(XmlObjectStates.BUILDING_OBJECT.name())
+                        .toState(XmlObjectStates.BUILDING_OBJECT)
                         .withActorsByName(XmlData.PROCESS_ELEMENT_START, XmlData.SIGNAL_ROOT_START)
                         .endTransition()
                     .transitionOnEvent((SaxEventAdapter.WHITESPACE))
@@ -817,13 +817,13 @@ public class XmlObjectBuilderAdapter implements StateTableControl<XmlEvent> {
                         .endTransition()
                     .withDefaultEventHandler(StateTransitionDefs.getUnexpectedEventDefaultTransition())
                     .endState()
-                .withState(XmlObjectStates.BUILDING_OBJECT.name())
+                .withState(XmlObjectStates.BUILDING_OBJECT)
                     .transitionOnEvent(SaxEventAdapter.START_ELEMENT)
-                        .toState(XmlObjectStates.BUILDING_OBJECT.name())
+                        .toState(XmlObjectStates.BUILDING_OBJECT)
                         .withActorsByName(XmlData.PROCESS_ELEMENT_START, XmlData.SIGNAL_ENTITY_START)
                         .endTransition()
                     .transitionOnEvent(SaxEventAdapter.CHARACTER_DATA)
-                        .toState(XmlObjectStates.BUILDING_FIELD.name())
+                        .toState(XmlObjectStates.BUILDING_FIELD)
                         .withActorsByName(XmlData.PROCESS_CHARACTER_DATA)
                         .endTransition()
                     .transitionOnEvent(SaxEventAdapter.WHITESPACE)
@@ -831,16 +831,16 @@ public class XmlObjectBuilderAdapter implements StateTableControl<XmlEvent> {
                         .withActorsByName(XmlData.PROCESS_WHITESPACE)
                         .endTransition()
                     .transitionOnEvent(SaxEventAdapter.END_ELEMENT)
-                        .toState(XmlObjectStates.BUILDING_OBJECT.name())
+                        .toState(XmlObjectStates.BUILDING_OBJECT)
                         .withActorsByName(XmlData.PROCESS_ELEMENT_END, XmlData.SIGNAL_OBJECT_DONE)
                         .endTransition()
                     .transitionOnEvent(SaxEventAdapter.END_DOCUMENT)
-                        .toState(XmlObjectStates.AWAITING_DOCUMENT.name())
+                        .toState(XmlObjectStates.AWAITING_DOCUMENT)
                         .withActorsByName(XmlData.PROCESS_DOCUMENT_END)
                         .endTransition()
                     .withDefaultEventHandler(StateTransitionDefs.getUnexpectedEventDefaultTransition())
                     .endState()
-                .withState(XmlObjectStates.BUILDING_FIELD.name())
+                .withState(XmlObjectStates.BUILDING_FIELD)
                     .transitionOnEvent(SaxEventAdapter.CHARACTER_DATA)
                         .toState(StateDef.STAY_IN_STATE)
                         .withActorsByName(XmlData.PROCESS_CHARACTER_DATA)
@@ -850,7 +850,7 @@ public class XmlObjectBuilderAdapter implements StateTableControl<XmlEvent> {
                         .withActorsByName(XmlData.PROCESS_WHITESPACE)
                         .endTransition()
                     .transitionOnEvent(SaxEventAdapter.END_ELEMENT)
-                        .toState(XmlObjectStates.BUILDING_OBJECT.name())
+                        .toState(XmlObjectStates.BUILDING_OBJECT)
                         .withActorsByName(XmlData.PROCESS_ELEMENT_END, XmlData.SIGNAL_SIMPLE_VALUE)
                         .endTransition()
                     .withDefaultEventHandler(StateTransitionDefs.getUnexpectedEventDefaultTransition())
@@ -959,7 +959,7 @@ public class XmlData extends AbstractStateTableData {
      * Construct with the controller to the state table that is able to build an object structure from events.
      */
     XmlData(@NotNull final StateTableControl<ObjectConstructionEvent> stateTableControl) {
-        super(XmlObjectStates.AWAITING_DOCUMENT.name(), XmlObjectStates.AWAITING_DOCUMENT.name());
+        super(XmlObjectStates.AWAITING_DOCUMENT, XmlObjectStates.AWAITING_DOCUMENT);
         this.stateTableControl = checkNotNull(stateTableControl, "stateTableControl must not be null");
         elementStack = new LinkedList<>();
         fieldValue = new StringBuilder();
@@ -1142,9 +1142,9 @@ public class ObjectConstructionController<T> implements StateTableControl<Object
                 .withStateTableDefinition()
                 .setName("ObjectBuilder")
                 .usingActorsInClass(ObjectData.class)
-                .withState(ObjectStates.AWAITING_ROOT_START.name())
+                .withState(ObjectStates.AWAITING_ROOT_START)
                     .transitionOnEvent(ObjectConstructionEvent.EVENT_ROOT_START)
-                        .toState(ObjectStates.AWAITING_ENTITY_START.name())
+                        .toState(ObjectStates.AWAITING_ENTITY_START)
                         .withActorsByName(ObjectData.PROCESS_ROOT_START)
                         .endTransition()
                     .transitionOnEvent(ObjectConstructionEvent.EVENT_DONE)
@@ -1153,47 +1153,47 @@ public class ObjectConstructionController<T> implements StateTableControl<Object
                         .endTransition()
                     .withDefaultEventHandler(StateTransitionDefs.getUnexpectedEventDefaultTransition())
                     .endState()
-                .withState(ObjectStates.AWAITING_ENTITY_START.name())
+                .withState(ObjectStates.AWAITING_ENTITY_START)
                     .transitionOnEvent(ObjectConstructionEvent.EVENT_ENTITY_START)
-                        .toStateConditionallyBeforeEvent(ObjectStates.BUILDING_LIST.name())
+                        .toStateConditionallyBeforeEvent(ObjectStates.BUILDING_LIST)
                             .when(ObjectData::isBuildingList)
-                            .elseGoToState(ObjectStates.BUILDING_ENTITY.name())
+                            .elseGoToState(ObjectStates.BUILDING_ENTITY)
                         .withActorsByName(ObjectData.PROCESS_ENTITY_START)
                         .endTransition()
                     .transitionOnEvent(ObjectConstructionEvent.EVENT_OBJECT_DONE)
-                        .toStateConditionally(ObjectStates.BUILDING_LIST.name())
+                        .toStateConditionally(ObjectStates.BUILDING_LIST)
                             .when(ObjectData::isBuildingList)
                             .elseStayInState()
                         .withActorsByName(ObjectData.PROCESS_OBJECT_DONE)
                         .endTransition()
                     .transitionOnEvent(ObjectConstructionEvent.EVENT_DONE)
-                        .toState(ObjectStates.AWAITING_ROOT_START.name())
+                        .toState(ObjectStates.AWAITING_ROOT_START)
                         .withActorsByName(ObjectData.PROCESS_DONE)
                         .endTransition()
                     .withDefaultEventHandler(StateTransitionDefs.getUnexpectedEventDefaultTransition())
                     .endState()
-                .withState(ObjectStates.BUILDING_ENTITY.name())
+                .withState(ObjectStates.BUILDING_ENTITY)
                     .transitionOnEvent(ObjectConstructionEvent.EVENT_ENTITY_START)
-                        .toState(ObjectStates.AWAITING_ENTITY_START.name())
+                        .toState(ObjectStates.AWAITING_ENTITY_START)
                         .withActorsByName(ObjectData.PROCESS_NESTED_ENTITY_START)
                         .endTransition()
                     .transitionOnEvent(ObjectConstructionEvent.EVENT_SIMPLE_VALUE)
-                        .toState(ObjectStates.AWAITING_ENTITY_START.name())
+                        .toState(ObjectStates.AWAITING_ENTITY_START)
                         .withActorsByName(ObjectData.PROCESS_SIMPLE_VALUE)
                         .endTransition()
                     .transitionOnEvent(ObjectConstructionEvent.EVENT_OBJECT_DONE)
-                        .toState(ObjectStates.AWAITING_ENTITY_START.name())
+                        .toState(ObjectStates.AWAITING_ENTITY_START)
                         .withActorsByName(ObjectData.PROCESS_OBJECT_DONE)
                         .endTransition()
                     .withDefaultEventHandler(StateTransitionDefs.getUnexpectedEventDefaultTransition())
                     .endState()
-                .withState(ObjectStates.BUILDING_LIST.name())
+                .withState(ObjectStates.BUILDING_LIST)
                     .transitionOnEvent(ObjectConstructionEvent.EVENT_ENTITY_START)
-                        .toState(ObjectStates.AWAITING_ENTITY_START.name())
+                        .toState(ObjectStates.AWAITING_ENTITY_START)
                         .withActorsByName(ObjectData.PROCESS_NESTED_ENTITY_START)
                         .endTransition()
                     .transitionOnEvent(ObjectConstructionEvent.EVENT_OBJECT_DONE)
-                        .toState(ObjectStates.AWAITING_ENTITY_START.name())
+                        .toState(ObjectStates.AWAITING_ENTITY_START)
                         .withActorsByName(ObjectData.PROCESS_OBJECT_DONE)
                         .endTransition()
                     .withDefaultEventHandler(StateTransitionDefs.getUnexpectedEventDefaultTransition())
@@ -1285,7 +1285,7 @@ public class ObjectData<T> extends AbstractStateTableData {
     private String itemName;
 
     ObjectData(@NotNull final Class<T> objectClass, @NotNull final Consumer<T> resultConsumer) {
-        super(ObjectStates.AWAITING_ROOT_START.name(), ObjectStates.AWAITING_ROOT_START.name());
+        super(ObjectStates.AWAITING_ROOT_START, ObjectStates.AWAITING_ROOT_START);
         this.objectClass = checkNotNull(objectClass, "objectClass must not be null");
         this.resultConsumer = checkNotNull(resultConsumer, "resultConsumer must not be null");
         this.objectBuilderStack = new LinkedList<>();

--- a/src/main/java/com/worthent/foundation/util/state/AbstractStateTableData.java
+++ b/src/main/java/com/worthent/foundation/util/state/AbstractStateTableData.java
@@ -69,7 +69,7 @@ public class AbstractStateTableData implements StateTableData {
      * @return the current state of the state table instance
      */
     @Nullable
-    public final String getCurrentState() {
+    public String getCurrentState() {
         return currentState;
     }
 
@@ -78,7 +78,7 @@ public class AbstractStateTableData implements StateTableData {
      *
      * @param currentState set the current state of the state table typically as the result of a completed transition
      */
-    public final void setCurrentState(@Nullable final String currentState) {
+    public void setCurrentState(@Nullable final String currentState) {
         this.currentState = currentState;
     }
 
@@ -88,7 +88,7 @@ public class AbstractStateTableData implements StateTableData {
      * @return the prior state of the state table instance
      */
     @Nullable
-    public final String getPriorState() {
+    public String getPriorState() {
         return priorState;
     }
 
@@ -98,7 +98,7 @@ public class AbstractStateTableData implements StateTableData {
      * @param priorState set the prior state of the state table typically from the previous current state as the result
      *                   of a completed transition
      */
-    public final void setPriorState(@Nullable final String priorState) {
+    public void setPriorState(@Nullable final String priorState) {
         this.priorState = priorState;
     }
 

--- a/src/main/java/com/worthent/foundation/util/state/StateEventBuilder.java
+++ b/src/main/java/com/worthent/foundation/util/state/StateEventBuilder.java
@@ -8,7 +8,7 @@ import com.worthent.foundation.util.annotation.Nullable;
  *
  * @author Erik K. Worth
  */
-public interface StateEventBuilder extends StateEventWithDataMap {
+public interface StateEventBuilder<E extends StateEventWithDataMap> extends StateEventWithDataMap {
 
     /**
      * Appends a data item to state event
@@ -26,5 +26,5 @@ public interface StateEventBuilder extends StateEventWithDataMap {
      * @return a new instance of the state event
      */
     @NotNull
-    StateEvent build();
+    E build();
 }

--- a/src/main/java/com/worthent/foundation/util/state/StateEventWithDataMap.java
+++ b/src/main/java/com/worthent/foundation/util/state/StateEventWithDataMap.java
@@ -17,10 +17,21 @@ public interface StateEventWithDataMap extends StateEvent {
      *
      * @param key the identifier for the data item
      * @param <T> the type of the data item
-     * @return the data item value identified by the key
+     * @return the data item value identified by the key or <code>null</code> when not present
      */
     @Nullable
     <T> T getEventData(@Nullable String key);
+
+    /**
+     * Returns an element of data by its key
+     *
+     * @param key the identifier for the data item
+     * @param <T> the type of the data item
+     * @return the data item value identified by the key
+     * @throws NullPointerException when the key does not identify a data value
+     */
+    @NotNull
+    <T> T getRequiredEventData(@Nullable String key);
 
     /**
      * Returns all the event data

--- a/src/main/java/com/worthent/foundation/util/state/TransitionContext.java
+++ b/src/main/java/com/worthent/foundation/util/state/TransitionContext.java
@@ -2,6 +2,8 @@ package com.worthent.foundation.util.state;
 
 import com.worthent.foundation.util.annotation.NotNull;
 
+import java.util.Set;
+
 /**
  * Specifies the information available from the context of transitioning from one state to another while processing
  * an event.
@@ -31,4 +33,14 @@ public interface TransitionContext<D extends StateTableData, E extends StateEven
     /** @return the event that trigger the state transition */
     @NotNull
     E getEvent();
+
+    /**
+     * Returns the potential states to which the state table will transition given that the transition may be based on
+     * defined conditions.
+     *
+     * @return the set of potential states to which the state table will transition
+     * @throws StateExeException thrown when there is no transition defined for the event in the "from" state
+     */
+    @NotNull
+    Set<String> getPotentialTargetStates();
 }

--- a/src/main/java/com/worthent/foundation/util/state/def/StateDef.java
+++ b/src/main/java/com/worthent/foundation/util/state/def/StateDef.java
@@ -36,7 +36,6 @@ import java.util.Collection;
  * given state is run.
  * 
  * @author Erik K. Worth
- * @version $Id: StateDef.java 2 2011-11-28 00:10:06Z erik.k.worth@gmail.com $
  */
 public interface StateDef<D extends StateTableData, E extends StateEvent> {
 

--- a/src/main/java/com/worthent/foundation/util/state/def/StateDefBuilder.java
+++ b/src/main/java/com/worthent/foundation/util/state/def/StateDefBuilder.java
@@ -24,6 +24,15 @@ public interface StateDefBuilder<D extends StateTableData, E extends StateEvent>
     StateTransitionDefBuilder<D, E> transitionOnEvent(@NotNull String eventName);
 
     /**
+     * Start building a state transition for this state on the provided event name
+     *
+     * @param event the event that triggers the state transition
+     * @return a reference to this builder
+     */
+    @NotNull
+    StateTransitionDefBuilder<D, E> transitionOnEvent(@NotNull Enum<?> event);
+
+    /**
      * Specifies the default state transition handler that handles events not specifically handled by other transitions
      *
      * @return a reference to this builder

--- a/src/main/java/com/worthent/foundation/util/state/def/StateDefException.java
+++ b/src/main/java/com/worthent/foundation/util/state/def/StateDefException.java
@@ -7,7 +7,6 @@ package com.worthent.foundation.util.state.def;
  * Thrown when there is an error or inconsistency in the state table definition.
  * 
  * @author Erik K. Worth
- * @version $Id: StateDefException.java 2 2011-11-28 00:10:06Z erik.k.worth@gmail.com $
  */
 public class StateDefException extends RuntimeException {
     

--- a/src/main/java/com/worthent/foundation/util/state/def/StateTableDefBuilder.java
+++ b/src/main/java/com/worthent/foundation/util/state/def/StateTableDefBuilder.java
@@ -44,6 +44,15 @@ public interface StateTableDefBuilder<D extends StateTableData, E extends StateE
     StateDefBuilder<D, E> withState(@NotNull String stateName);
 
     /**
+     * Returns a new builder for a state in the state table with the provided name
+     *
+     * @param state the state to start defining
+     * @return a reference to the state definition builder
+     */
+    @NotNull
+    StateDefBuilder<D, E> withState(@NotNull Enum<?> state);
+
+    /**
      * Appends a state definition to the state table
      *
      * @param state the state definition to append to the state table

--- a/src/main/java/com/worthent/foundation/util/state/def/StateTransitionDef.java
+++ b/src/main/java/com/worthent/foundation/util/state/def/StateTransitionDef.java
@@ -1,16 +1,17 @@
 package com.worthent.foundation.util.state.def;
 
+import com.worthent.foundation.util.annotation.NotNull;
 import com.worthent.foundation.util.state.StateEvent;
 import com.worthent.foundation.util.state.StateTableData;
 import com.worthent.foundation.util.state.TransitionActor;
 
 import java.util.List;
+import java.util.Set;
 
 /**
  * Specifies the information available on a state transition.
  *
  * @author Erik K. Worth
- * @version $Id: StateTransitionDef.java 2 2011-11-28 00:10:06Z erik.k.worth@gmail.com $
  */
 public interface StateTransitionDef<D extends StateTableData, E extends StateEvent> {
 
@@ -20,15 +21,25 @@ public interface StateTransitionDef<D extends StateTableData, E extends StateEve
     /**
      * @return the event identifier associated with this transition.
      */
+    @NotNull
     String getEventName();
 
     /**
      * @return the identifier for the target state when the transition completes.
      */
+    @NotNull
     String getTargetStateName();
+
+    /**
+     * @return the identifiers for states to which this transition can possibly go based on evaluation conditions.  It
+     * returns the single target state for unconditional transitions.
+     */
+    @NotNull
+    Set<String> getPotentialTargetStateNames();
 
     /**
      * @return the ordered list of components able to perform actions on this transition for a given event.
      */
+    @NotNull
     List<TransitionActor<D, E>> getActors();
 }

--- a/src/main/java/com/worthent/foundation/util/state/def/StateTransitionDefBuilder.java
+++ b/src/main/java/com/worthent/foundation/util/state/def/StateTransitionDefBuilder.java
@@ -25,6 +25,15 @@ public interface StateTransitionDefBuilder<D extends StateTableData, E extends S
     StateTransitionDefBuilder<D, E> toState(@NotNull String targetStateName);
 
     /**
+     * Transition to this state for the provided event
+     *
+     * @param targetState the target state of the state transition
+     * @return a reference to this builder
+     */
+    @NotNull
+    StateTransitionDefBuilder<D, E> toState(@NotNull Enum<?> targetState);
+
+    /**
      * Transition to the state when the corresponding condition is satisfied (after processing the event)
      *
      * @param goToState the target state based on the first condition built by the returned builder
@@ -34,12 +43,31 @@ public interface StateTransitionDefBuilder<D extends StateTableData, E extends S
     ToStateConditionBuilder<D, E> toStateConditionally(@NotNull String goToState);
 
     /**
+     * Transition to the state when the corresponding condition is satisfied (after processing the event)
+     *
+     * @param goToState the target state based on the first condition built by the returned builder
+     * @return a reference to transition condition builder
+     */
+    @NotNull
+    ToStateConditionBuilder<D, E> toStateConditionally(@NotNull Enum<?> goToState);
+
+    /**
      * Transition to the state when the corresponding condition is satisfied (before processing the event)
      *
      * @param goToState the target state based on the first condition built by the returned builder
      * @return a reference to the transition condition builder
      */
+    @NotNull
     ToStateConditionBuilder<D, E> toStateConditionallyBeforeEvent(@NotNull String goToState);
+
+    /**
+     * Transition to the state when the corresponding condition is satisfied (before processing the event)
+     *
+     * @param goToState the target state based on the first condition built by the returned builder
+     * @return a reference to the transition condition builder
+     */
+    @NotNull
+    ToStateConditionBuilder<D, E> toStateConditionallyBeforeEvent(@NotNull Enum<?> goToState);
 
     /**
      * Have this actor perform its function in the order added during the state transition

--- a/src/main/java/com/worthent/foundation/util/state/def/ToStateConditionListBuilder.java
+++ b/src/main/java/com/worthent/foundation/util/state/def/ToStateConditionListBuilder.java
@@ -19,13 +19,25 @@ public interface ToStateConditionListBuilder<D extends StateTableData, E extends
      *                    <code>true</code>
      * @return a reference to a new condition builder
      */
+    @NotNull
     ToStateConditionBuilder<D, E> orToState(@NotNull String toStateName);
+
+    /**
+     * Returns the To State Condition Builder to capture the predicate used to decide to go to this state or not
+     *
+     * @param toState the target state for the returned condition builder when the condition evaluates to
+     *                <code>true</code>
+     * @return a reference to a new condition builder
+     */
+    @NotNull
+    ToStateConditionBuilder<D, E> orToState(@NotNull final Enum<?> toState);
 
     /**
      * Returns to the state transition builder after making sure an exception is thrown when no condition matches
      *
      * @return a reference to parent transition builder
      */
+    @NotNull
     StateTransitionDefBuilder<D, E> elseFail();
 
     /**
@@ -34,6 +46,7 @@ public interface ToStateConditionListBuilder<D extends StateTableData, E extends
      *
      * @return a reference to the parent transition builder
      */
+    @NotNull
     StateTransitionDefBuilder<D, E> elseStayInState();
 
     /**
@@ -43,5 +56,16 @@ public interface ToStateConditionListBuilder<D extends StateTableData, E extends
      * @param toStateName the target state when the conditions all evaluate to <code>false</code>
      * @return a reference to the parent transition builder
      */
+    @NotNull
     StateTransitionDefBuilder<D, E> elseGoToState(@NotNull String toStateName);
+
+    /**
+     * Returns to the state transition builder after making sure the state table transitions to this state when no
+     * other conditions match
+     *
+     * @param toState the target state when the conditions all evaluate to <code>false</code>
+     * @return a reference to the parent transition builder
+     */
+    @NotNull
+    StateTransitionDefBuilder<D, E> elseGoToState(@NotNull Enum<?> toState);
 }

--- a/src/main/java/com/worthent/foundation/util/state/def/impl/StateDefBuilderImpl.java
+++ b/src/main/java/com/worthent/foundation/util/state/def/impl/StateDefBuilderImpl.java
@@ -63,6 +63,12 @@ public class StateDefBuilderImpl<D extends StateTableData, E extends StateEvent>
 
     @Override
     @NotNull
+    public StateTransitionDefBuilder<D, E> transitionOnEvent(@NotNull final Enum<?> event) {
+        return transitionOnEvent(checkNotNull(event, "event must not be blank").name());
+    }
+
+    @Override
+    @NotNull
     public StateTransitionDefBuilder<D, E> withDefaultEventHandler() {
         return new StateTransitionDefBuilderImpl<>(this, transitionActorManager, StateTransitionDefImpl.DEFAULT_HANDLER_EVENT_ID);
     }

--- a/src/main/java/com/worthent/foundation/util/state/def/impl/StateTableDefBuilderImpl.java
+++ b/src/main/java/com/worthent/foundation/util/state/def/impl/StateTableDefBuilderImpl.java
@@ -138,6 +138,12 @@ public class StateTableDefBuilderImpl<D extends StateTableData, E extends StateE
 
     @NotNull
     @Override
+    public StateDefBuilder<D, E> withState(@NotNull final Enum<?> state) {
+        return withState(checkNotNull(state, "state must not be null").name());
+    }
+
+    @NotNull
+    @Override
     public StateTableDefBuilder<D, E> appendState(@NotNull final StateDef<D, E> state) {
         states.add(checkNotNull(state, "status must not be null"));
         return this;

--- a/src/main/java/com/worthent/foundation/util/state/def/impl/StateTransitionDefBuilderImpl.java
+++ b/src/main/java/com/worthent/foundation/util/state/def/impl/StateTransitionDefBuilderImpl.java
@@ -1,18 +1,20 @@
-/*
- * Copyright 2000-2015 Worth Enterprises, Inc.  All rights reserved.
- */
 package com.worthent.foundation.util.state.def.impl;
 
 import com.worthent.foundation.util.annotation.NotNull;
 import com.worthent.foundation.util.state.StateEvent;
 import com.worthent.foundation.util.state.StateTableData;
 import com.worthent.foundation.util.state.TransitionActor;
-import com.worthent.foundation.util.state.def.*;
+import com.worthent.foundation.util.state.def.StateDef;
+import com.worthent.foundation.util.state.def.StateDefBuilder;
+import com.worthent.foundation.util.state.def.StateTransitionDef;
+import com.worthent.foundation.util.state.def.StateTransitionDefBuilder;
+import com.worthent.foundation.util.state.def.ToStateConditionBuilder;
 import com.worthent.foundation.util.state.provider.ToStateNavigationActor;
 
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.worthent.foundation.util.condition.Preconditions.checkNotBlank;
@@ -84,21 +86,26 @@ public class StateTransitionDefBuilderImpl<D extends StateTableData, E extends S
 
     @Override
     @NotNull
+    public Set<String> getPotentialTargetStateNames() {
+        return StateTransitionDefImpl.getPotentialTargetStateNames(goToState, transitionActors);
+    }
+
+    @Override
+    @NotNull
     public List<TransitionActor<D, E>> getActors() {
         return transitionActors;
     }
 
     @NotNull
     @Override
-    public StateTransitionDefBuilder<D, E> toState(@NotNull final String goToState) {
-        if (null == goToState) {
-            throw new IllegalArgumentException("goToState must not be null");
-        }
-        if (goToState.trim().length() == 0) {
-            throw new IllegalArgumentException("goToState must not be blank");
-        }
-        this.goToState = goToState;
+    public StateTransitionDefBuilder<D, E> toState(@NotNull final String targetStateName) {
+        this.goToState = checkNotBlank(targetStateName, "targetStateName must not be blank");
         return this;
+    }
+
+    @Override
+    public StateTransitionDefBuilder<D, E> toState(Enum<?> targetState) {
+        return toState(checkNotNull(targetState, "targetState must not be null").name());
     }
 
     @Override
@@ -111,10 +118,21 @@ public class StateTransitionDefBuilderImpl<D extends StateTableData, E extends S
 
     @Override
     @NotNull
+    public ToStateConditionBuilder<D, E> toStateConditionally(@NotNull final Enum<?> goToState) {
+        return toStateConditionally(checkNotNull(goToState, "gotoState must not be null").name());
+    }
+
+    @Override
+    @NotNull
     public ToStateConditionBuilder<D, E> toStateConditionallyBeforeEvent(@NotNull final String goToState) {
         final ToStateConditionListBuilderImpl<D, E> toStateConditionListBuilder =
                 new ToStateConditionListBuilderImpl<>(this, ToStateConditionListBuilderImpl.CheckPosition.BEFORE_ACTORS);
-        return toStateConditionListBuilder.orToState(checkNotNull(goToState, "goToState must not be null"));
+        return toStateConditionListBuilder.orToState(checkNotBlank(goToState, "goToState must not be null"));
+    }
+
+    @Override
+    public ToStateConditionBuilder<D, E> toStateConditionallyBeforeEvent(Enum<?> goToState) {
+        return toStateConditionallyBeforeEvent(checkNotNull(goToState, "gotoState must not be null").name());
     }
 
     @Override

--- a/src/main/java/com/worthent/foundation/util/state/def/impl/StateTransitionDefImpl.java
+++ b/src/main/java/com/worthent/foundation/util/state/def/impl/StateTransitionDefImpl.java
@@ -4,10 +4,14 @@ import com.worthent.foundation.util.annotation.NotNull;
 import com.worthent.foundation.util.state.StateEvent;
 import com.worthent.foundation.util.state.StateTableData;
 import com.worthent.foundation.util.state.TransitionActor;
+import com.worthent.foundation.util.state.def.StateDef;
 import com.worthent.foundation.util.state.def.StateTransitionDef;
+import com.worthent.foundation.util.state.provider.ToStateNavigationActor;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 
 import static com.worthent.foundation.util.condition.Preconditions.checkNotNull;
 
@@ -15,7 +19,6 @@ import static com.worthent.foundation.util.condition.Preconditions.checkNotNull;
  * Immutably encapsulates the information for a state transition definition.
  * 
  * @author Erik K. Worth
- * @version $Id: StateTransitionDefImpl.java 2 2011-11-28 00:10:06Z erik.k.worth@gmail.com $
  */
 public class StateTransitionDefImpl<D extends StateTableData, E extends StateEvent> implements StateTransitionDef<D, E> {
 
@@ -100,18 +103,59 @@ public class StateTransitionDefImpl<D extends StateTableData, E extends StateEve
         return 31 * onEvent.hashCode() + goToState.hashCode();
     }
 
+    @NotNull
     @Override
     public final String getEventName() {
         return onEvent;
     }
 
+    @NotNull
     @Override
     public final String getTargetStateName() {
         return goToState;
     }
 
+    @NotNull
+    @Override
+    public Set<String> getPotentialTargetStateNames() {
+        return getPotentialTargetStateNames(goToState, actors);
+    }
+
+    @NotNull
     @Override
     public final List<TransitionActor<D, E>> getActors() {
         return actors;
+    }
+
+    /**
+     * Returns the list of potential target states to which the state table may transition.
+     *
+     * @param goToState the configured target state
+     * @param actors the list of actors, one of which might govern the target state
+     * @param <D> the state table data type
+     * @param <E> the state table event type
+     * @return the list of potential target states to which the state table may transition
+     */
+    static <D extends StateTableData, E extends StateEvent> Set<String> getPotentialTargetStateNames(
+            final String goToState,
+            final List<TransitionActor<D, E>> actors) {
+        if (actors.isEmpty()) {
+            return Collections.singleton(goToState);
+        }
+        if (!StateDef.STATE_CHANGE_BY_ACTOR.equalsIgnoreCase(goToState)) {
+            // Conditional state transitions use a special actor to determine the target state.  Thus the target state
+            // is always STATE_CHANGE_BY_ACTOR.  If the target state is not this value, then the target state is the
+            // only state to which the transition can go.
+            return Collections.singleton(goToState);
+        }
+        final Optional<ToStateNavigationActor<D, E>> toStateNavigationActor = actors.stream()
+                .filter(a -> a instanceof ToStateNavigationActor)
+                .map(a -> (ToStateNavigationActor<D, E>)a)
+                .findFirst();
+        // If the special actor is not found, it is still possible for the integrator to have provided their own
+        // actor that governs the state change.  In that case, we do not know where it will go.
+        return toStateNavigationActor.isPresent()
+                ? toStateNavigationActor.get().getPossibleTargetStates()
+                : Collections.singleton(goToState);
     }
 }

--- a/src/main/java/com/worthent/foundation/util/state/def/impl/ToStateCondition.java
+++ b/src/main/java/com/worthent/foundation/util/state/def/impl/ToStateCondition.java
@@ -11,7 +11,14 @@ import com.worthent.foundation.util.state.TransitionContext;
  */
 public interface ToStateCondition<D extends StateTableData, E extends StateEvent> {
 
+    /** @return the state to which the transition will go if the test condition returns <code>true</code> */
     String getToState();
 
+    /**
+     * The default implementation of the test condition always returns <code>true</code>.
+     *
+     * @param transitionContext the context for the state transition
+     * @return the result of the test
+     */
     default boolean test(TransitionContext<D, E> transitionContext) {return true;}
 }

--- a/src/main/java/com/worthent/foundation/util/state/def/impl/ToStateConditionListBuilderImpl.java
+++ b/src/main/java/com/worthent/foundation/util/state/def/impl/ToStateConditionListBuilderImpl.java
@@ -23,13 +23,24 @@ public class ToStateConditionListBuilderImpl<D extends StateTableData, E extends
     extends AbstractChildBuilder<StateTransitionDefBuilderImpl<D, E>>
         implements ToStateConditionListBuilder<D, E> {
 
+    /** Enumerates the points before and after actors are run when the condition can be checked */
     public enum CheckPosition {
         BEFORE_ACTORS,
-        AFTER_ACTORS;
+        AFTER_ACTORS
     }
+
+    /** The point before or after actors are run when the condition is checked */
     private final CheckPosition checkPosition;
+
+    /** The list of conditional state transitions being built */
     private final List<ToStateCondition<D, E>> toStateConditions;
 
+    /**
+     * Construct from the parent builder and the position where the condition is to be checked.
+     *
+     * @param parentBuilder the parent builder
+     * @param checkPosition the position where the condition is to be checked (before or after actors are run)
+     */
     ToStateConditionListBuilderImpl(
             @NotNull final StateTransitionDefBuilderImpl<D, E> parentBuilder,
             @NotNull final CheckPosition checkPosition) {
@@ -43,10 +54,19 @@ public class ToStateConditionListBuilderImpl<D extends StateTableData, E extends
     }
 
     @Override
+    @NotNull
     public ToStateConditionBuilder<D, E> orToState(@NotNull final String toStateName) {
         return new ToStateConditionBuilderImpl<>(this, checkNotNull(toStateName, "toStateName must not be null"));
     }
 
+    @Override
+    @NotNull
+    public ToStateConditionBuilder<D, E> orToState(@NotNull final Enum<?> toState) {
+        return new ToStateConditionBuilderImpl<>(this, checkNotNull(toState, "toState must not be null").name());
+    }
+
+    @Override
+    @NotNull
     public StateTransitionDefBuilder<D, E> elseFail() {
         // The resulting actor fails when none of the conditions are satisfied, so we do nothing here.
         final StateTransitionDefBuilderImpl<D, E> parentBuilder = getParentBuilder();
@@ -54,6 +74,8 @@ public class ToStateConditionListBuilderImpl<D extends StateTableData, E extends
         return parentBuilder;
     }
 
+    @Override
+    @NotNull
     public StateTransitionDefBuilder<D, E> elseStayInState() {
         final StateTransitionDefBuilderImpl<D, E> parentBuilder = getParentBuilder();
         // Add a condition that always returns true and where the To State directs it to stay in the current state
@@ -63,11 +85,18 @@ public class ToStateConditionListBuilderImpl<D extends StateTableData, E extends
     }
 
     @Override
+    @NotNull
     public StateTransitionDefBuilder<D, E> elseGoToState(@NotNull String toStateName) {
         final StateTransitionDefBuilderImpl<D, E> parentBuilder = getParentBuilder();
         // Add a condition that always returns true and where the To State directs it to go to the specified state
         toStateConditions.add(() -> toStateName);
         parentBuilder.setToStateConditions(toStateConditions, checkPosition);
         return parentBuilder;
+    }
+
+    @Override
+    @NotNull
+    public StateTransitionDefBuilder<D, E> elseGoToState(@NotNull Enum<?> toState) {
+        return elseGoToState(checkNotNull(toState, "toState must not be null").name());
     }
 }

--- a/src/main/java/com/worthent/foundation/util/state/impl/StateEventBuilderImpl.java
+++ b/src/main/java/com/worthent/foundation/util/state/impl/StateEventBuilderImpl.java
@@ -2,8 +2,8 @@ package com.worthent.foundation.util.state.impl;
 
 import com.worthent.foundation.util.annotation.NotNull;
 import com.worthent.foundation.util.annotation.Nullable;
-import com.worthent.foundation.util.state.StateEvent;
 import com.worthent.foundation.util.state.StateEventBuilder;
+import com.worthent.foundation.util.state.StateEventWithDataMap;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -14,7 +14,7 @@ import static com.worthent.foundation.util.condition.Preconditions.checkNotNull;
 /**
  * Implements the builder interface for state events.
  */
-public class StateEventBuilderImpl implements StateEventBuilder {
+public class StateEventBuilderImpl<E extends StateEventWithDataMap> implements StateEventBuilder<E> {
 
     /** The name of the event being built */
     private final String eventName;
@@ -47,21 +47,29 @@ public class StateEventBuilderImpl implements StateEventBuilder {
 
     @Override
     @NotNull
+    public <T> T getRequiredEventData(@Nullable final String key) {
+        return checkNotNull(getEventData(key), key + " missing from event data");
+    }
+
+    @Override
+    @NotNull
     public Map<String, Object> getEventData() {
         return eventData;
     }
 
     @Override
     @NotNull
-    public StateEventBuilder withEventData(@NotNull final String name, @Nullable final Object value) {
+    public StateEventBuilder<E> withEventData(@NotNull final String name, @Nullable final Object value) {
         checkNotNull(name, "name must not be null");
         eventData.put(name, value);
         return this;
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     @NotNull
-    public StateEvent build() {
-        return new StateEventWithDataMapImpl(eventName, eventData);
+    public E build() {
+        final StateEventWithDataMap event = new StateEventWithDataMapImpl(eventName, eventData);
+        return (E) event;
     }
 }

--- a/src/main/java/com/worthent/foundation/util/state/impl/StateEventWithDataMapImpl.java
+++ b/src/main/java/com/worthent/foundation/util/state/impl/StateEventWithDataMapImpl.java
@@ -5,6 +5,7 @@ package com.worthent.foundation.util.state.impl;
 
 import com.worthent.foundation.util.annotation.NotNull;
 import com.worthent.foundation.util.annotation.Nullable;
+import com.worthent.foundation.util.state.StateEvent;
 import com.worthent.foundation.util.state.StateEventWithDataMap;
 
 import java.util.Collections;
@@ -46,6 +47,12 @@ public class StateEventWithDataMapImpl implements StateEventWithDataMap {
     @Nullable
     public <T> T getEventData(@Nullable final String key) {
         return (T) eventData.get(key);
+    }
+
+    @Override
+    @NotNull
+    public <T> T getRequiredEventData(@Nullable final String key) {
+        return checkNotNull(getEventData(key), key + " missing from event data");
     }
 
     @Override

--- a/src/main/java/com/worthent/foundation/util/state/impl/TransitionContextImpl.java
+++ b/src/main/java/com/worthent/foundation/util/state/impl/TransitionContextImpl.java
@@ -8,6 +8,9 @@ import com.worthent.foundation.util.state.StateTable;
 import com.worthent.foundation.util.state.StateTableControl;
 import com.worthent.foundation.util.state.StateTableData;
 import com.worthent.foundation.util.state.TransitionContext;
+import com.worthent.foundation.util.state.def.StateTransitionDef;
+
+import java.util.Set;
 
 /**
  * Encapsulates all the elements involved in the state table transition.
@@ -65,5 +68,11 @@ public class TransitionContextImpl<D extends StateTableData, E extends StateEven
     @Override
     public E getEvent() {
         return event;
+    }
+
+    public Set<String> getPotentialTargetStates() {
+        return stateTable.getStateTableDefinition()
+                .getTransition(fromState, event.getName())
+                .getPotentialTargetStateNames();
     }
 }

--- a/src/main/java/com/worthent/foundation/util/state/provider/SerialStateTableControl.java
+++ b/src/main/java/com/worthent/foundation/util/state/provider/SerialStateTableControl.java
@@ -16,7 +16,6 @@ import static com.worthent.foundation.util.condition.Preconditions.checkNotNull;
  * processed.
  * 
  * @author Erik K. Worth
- * @version $Id: SerialStateTableControl.java 2 2011-11-28 00:10:06Z erik.k.worth@gmail.com $
  */
 public class SerialStateTableControl<D extends StateTableData, E extends StateEvent> implements StateTableControl<E> {
 

--- a/src/main/java/com/worthent/foundation/util/state/provider/SingleThreadConsumerStateTableControl.java
+++ b/src/main/java/com/worthent/foundation/util/state/provider/SingleThreadConsumerStateTableControl.java
@@ -1,0 +1,159 @@
+package com.worthent.foundation.util.state.provider;
+
+import com.worthent.foundation.util.annotation.NotNull;
+import com.worthent.foundation.util.annotation.Nullable;
+import com.worthent.foundation.util.state.StateEvent;
+import com.worthent.foundation.util.state.StateExeException;
+import com.worthent.foundation.util.state.StateTable;
+import com.worthent.foundation.util.state.StateTableControl;
+import com.worthent.foundation.util.state.StateTableData;
+import com.worthent.foundation.util.state.impl.StateEngine;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static com.worthent.foundation.util.condition.Preconditions.checkNotNull;
+
+/**
+ * Implements the {@link StateTableControl} interface to provide a single-threaded implementation of the state table.
+ * The state table transition actions are all conducted asynchronously on the same single thread in the order they arrive.
+ *
+ * @author Erik K. Worth
+ */
+public class SingleThreadConsumerStateTableControl<D extends StateTableData, E extends StateEvent>
+        implements StateTableControl<E>, Closeable {
+
+    /** Logger for this class */
+    private static final Logger LOGGER = LoggerFactory.getLogger(SingleThreadConsumerStateTableControl.class);
+
+    /** Exception message when attempting to submit an event when the state table is shut down */
+    public static final String MSG_STATE_TABLE_SHUT_DOWN = "State Table is shut down";
+
+    /** The default thread group name when a thread group is not provided in the constructor */
+    private static final String DEFAULT_THREAD_GROUP_NAME = "single-thread-state-table";
+
+    /** Counts the number of instances of this class to use as the name of the single thread for this state table */
+    private static final AtomicInteger instance_count = new AtomicInteger(0);
+
+    /** The state table engine that processes events */
+    private final StateEngine<D, E> engine;
+
+    /** The state table instance */
+    private final StateTable<D, E> stateTblInstance;
+
+    /** The event queue */
+    private final LinkedBlockingDeque<E> eventQueue;
+
+    /** Set to <code>true</code> when the state table is stopping */
+    private volatile boolean stopping = false;
+
+    /** The single thread used to process all events */
+    private Thread thread;
+
+    /**
+     * Construct with the state table instance and an optional thread group for the single thread.
+     *
+     * @param stateTblInstance the state table to be fed events from the single thread in the order the events are signaled
+     * @param threadGroup the optional thread group
+     */
+    public SingleThreadConsumerStateTableControl(
+            @NotNull final StateTable<D, E> stateTblInstance,
+            @Nullable final ThreadGroup threadGroup) {
+        final ThreadGroup threadGrp = (null == threadGroup)
+                ? new ThreadGroup(DEFAULT_THREAD_GROUP_NAME)
+                : threadGroup;
+        this.engine = new StateEngine<>();
+        this.stateTblInstance = checkNotNull(stateTblInstance, "stateTblInstance must not be null");
+        this.thread = new Thread(
+                threadGroup,
+                this::processEvents,
+                threadGrp.getName() + '-' + instance_count.incrementAndGet());
+        this.thread.setDaemon(true); // do not prevent the process from shutting down
+        this.eventQueue = new LinkedBlockingDeque<>();
+    }
+
+    /**
+     * Construct with the state table instance.
+     *
+     * @param stateTblInstance the state table to be fed events from the single thread in the order the events are signaled
+     */
+    public SingleThreadConsumerStateTableControl(@NotNull final StateTable<D, E> stateTblInstance) {
+        this(stateTblInstance, null);
+    }
+
+    //
+    // Closeable Interface
+    //
+
+    @Override
+    public void close() throws IOException {
+        stop();
+    }
+
+    //
+    // StateTableControl Interface
+    //
+
+    @Override
+    public void start() throws StateExeException {
+        try {
+            stateTblInstance.getStateTableDataManager().initializeStateTableData();
+        } catch (Exception exc) {
+            final String name = stateTblInstance.getStateTableName();
+            throw new StateExeException("Error initializing state table history for state table, " + name);
+        }
+        thread.start();
+    }
+
+    @Override
+    public void stop() throws StateExeException {
+        stopping = true;
+        thread.interrupt();
+    }
+
+    @Override
+    public void signalEvent(@NotNull final E event) throws StateExeException {
+        checkNotNull(event, "event must not be null");
+        if (!thread.isAlive()) {
+            throw new StateExeException(MSG_STATE_TABLE_SHUT_DOWN);
+        }
+        eventQueue.add(event);
+    }
+
+    /**
+     * Injects an event into the front of the queue submitted to the state table.
+     *
+     * @param event the event to inject into the front of the queue
+     */
+    public void injectEvent(@NotNull final E event) throws StateExeException {
+        checkNotNull(event, "event must not be null");
+        if (!thread.isAlive()) {
+            throw new StateExeException(MSG_STATE_TABLE_SHUT_DOWN);
+        }
+        eventQueue.addFirst(event);
+    }
+
+    /** The method run from within the single thread that processes events */
+    private void processEvents() {
+        while (!stopping) {
+            E event = null;
+            try {
+                event = eventQueue.take();
+                if (null != event) {
+                    LOGGER.debug("Process event: {}", event);
+                    engine.processEvent(stateTblInstance, this, event);
+                }
+            } catch (final InterruptedException exc) {
+                LOGGER.info("State Table Thread interrupted");
+            } catch (final Exception exc) {
+                LOGGER.error("Error processing event " + event, exc);
+            }
+        }
+        LOGGER.info("State Table thread has stopped.");
+    }
+
+}

--- a/src/main/java/com/worthent/foundation/util/state/provider/ToStateNavigationActor.java
+++ b/src/main/java/com/worthent/foundation/util/state/provider/ToStateNavigationActor.java
@@ -11,6 +11,8 @@ import com.worthent.foundation.util.state.def.impl.ToStateCondition;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static com.worthent.foundation.util.condition.Preconditions.checkNotNull;
 
@@ -33,6 +35,11 @@ public class ToStateNavigationActor<D extends StateTableData, E extends StateEve
      */
     public ToStateNavigationActor(@NotNull final List<ToStateCondition<D, E>> toStateConditions) {
         this.toStateConditions = checkNotNull(toStateConditions, "toStateConditions must not be null");
+    }
+
+    /** @return the set of states to which this actor may direct the state transition */
+    public Set<String> getPossibleTargetStates() {
+        return toStateConditions.stream().map(ToStateCondition::getToState).collect(Collectors.toSet());
     }
 
     @Override

--- a/src/test/java/com/worthent/foundation/util/state/examples/turnstyle/SingleThreadConsumerStateTableControlTest.java
+++ b/src/test/java/com/worthent/foundation/util/state/examples/turnstyle/SingleThreadConsumerStateTableControlTest.java
@@ -1,0 +1,105 @@
+package com.worthent.foundation.util.state.examples.turnstyle;
+
+import com.worthent.foundation.util.state.StateEvent;
+import com.worthent.foundation.util.state.StateExeException;
+import com.worthent.foundation.util.state.provider.SingleThreadConsumerStateTableControl;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.LinkedBlockingQueue;
+
+import static com.worthent.foundation.util.state.examples.turnstyle.TurnstileStateTable.OFF_EVENT;
+import static com.worthent.foundation.util.state.examples.turnstyle.TurnstileStateTable.ON_EVENT;
+import static com.worthent.foundation.util.state.examples.turnstyle.TurnstileStateTable.PUSH_EVENT;
+import static com.worthent.foundation.util.state.examples.turnstyle.TurnstileStateTable.TICKET_EVENT;
+import static com.worthent.foundation.util.state.examples.turnstyle.TurnstileStateTable.assertExpectedState;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test cases for the builder that defines a state table.
+ *
+ * @author Erik K. Worth
+ */
+public class SingleThreadConsumerStateTableControlTest {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SerialStateTableControlTest.class);
+
+    /** The list of state transitions through which the state table transitioned during the test */
+    private LinkedBlockingQueue<String> stateQueue;
+
+    /** The state table used to test the controller */
+    private TurnstileStateTable turnstileStateTable;
+
+    @Rule
+    public TestWatcher watchman= new TestWatcher() {
+        @Override
+        public void starting(final Description description) {
+            LOGGER.debug("Starting test {}", description.getMethodName());
+        }
+    };
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Before
+    public void setup() {
+        stateQueue = new LinkedBlockingQueue<>();
+        turnstileStateTable = new TurnstileStateTable(stateQueue);
+    }
+
+    @Test
+    public void testOneTurnstileEntry() throws Exception {
+        try (final SingleThreadConsumerStateTableControl<TurnstileData, StateEvent> stateTableController =
+                     new SingleThreadConsumerStateTableControl<>(turnstileStateTable.getTurnstileStateTable())) {
+            stateTableController.start();
+            stateTableController.signalEvent(ON_EVENT);
+            stateTableController.signalEvent(TICKET_EVENT);
+            stateTableController.signalEvent(PUSH_EVENT);
+            stateTableController.signalEvent(OFF_EVENT);
+
+            assertExpectedState(stateQueue, TurnstileStates.LOCKED);
+            assertExpectedState(stateQueue, TurnstileStates.UNLOCKED);
+            assertExpectedState(stateQueue, TurnstileStates.LOCKED);
+            assertExpectedState(stateQueue, TurnstileStates.OFF);
+            assertTrue("Expected empty stateQueue", stateQueue.isEmpty());
+
+            final TurnstileData stateTableData = turnstileStateTable.getStateTableData();
+            assertEquals("Expected Turn Count", 1, stateTableData.getTurnCount());
+            assertEquals("Expected Ticket Count", 1, stateTableData.getTicketCount());
+        }
+    }
+
+
+    @Test
+    public void testOnOffStopAndSignalEvent() throws Exception {
+        thrown.expect(StateExeException.class);
+        thrown.expectMessage(SingleThreadConsumerStateTableControl.MSG_STATE_TABLE_SHUT_DOWN);
+
+        final SingleThreadConsumerStateTableControl<TurnstileData, StateEvent> stateTableController =
+                     new SingleThreadConsumerStateTableControl<>(turnstileStateTable.getTurnstileStateTable());
+
+        stateTableController.start();
+        stateTableController.signalEvent(ON_EVENT);
+
+        assertExpectedState(stateQueue, TurnstileStates.LOCKED);
+        stateTableController.injectEvent(OFF_EVENT);
+
+        assertExpectedState(stateQueue, TurnstileStates.OFF);
+        assertTrue("Expected empty stateQueue", stateQueue.isEmpty());
+
+        // Stop and wait a moment for it to stop
+        stateTableController.stop();
+        Thread.sleep(200);
+
+        // This should fail
+        stateTableController.signalEvent(ON_EVENT);
+    }
+
+}

--- a/src/test/java/com/worthent/foundation/util/state/examples/turnstyle/TurnstileData.java
+++ b/src/test/java/com/worthent/foundation/util/state/examples/turnstyle/TurnstileData.java
@@ -5,22 +5,31 @@ import com.worthent.foundation.util.state.StateEvent;
 import com.worthent.foundation.util.state.TransitionContext;
 import com.worthent.foundation.util.state.annotation.Actor;
 
+import java.util.Queue;
+
+import static com.worthent.foundation.util.condition.Preconditions.checkNotNull;
+
 /** The state table data object for the turnstile */
 public class TurnstileData extends AbstractStateTableData {
 
     /** The name of the actor that increments the turn and ticket counts */
     public static final String INCREMENT_COUNT = "incrementCount";
 
+    /** Provided for testing to track state transitions */
+    private final Queue<String> stateQueue;
+
     /** The number of people that passed through the turnstile */
     private int turnCount;
+
     /** The number of tickets scanned for the turnstile */
     private int ticketCount;
 
     /** Construct in initial state */
-    public TurnstileData() {
+    public TurnstileData(final Queue<String> stateQueue) {
         super(TurnstileStates.OFF.name(), TurnstileStates.OFF.name());
         turnCount = 0;
         ticketCount = 0;
+        this.stateQueue = checkNotNull(stateQueue, "stateQueue must not be null");
     }
 
     /** Copy constructor */
@@ -28,6 +37,7 @@ public class TurnstileData extends AbstractStateTableData {
         super(other);
         this.turnCount = other.getTurnCount();
         this.ticketCount = other.getTicketCount();
+        this.stateQueue = other.getStateQueue();
     }
 
     /** Set from other state */
@@ -35,6 +45,7 @@ public class TurnstileData extends AbstractStateTableData {
         super.set(other);
         this.turnCount = other.getTurnCount();
         this.ticketCount = other.getTicketCount();
+        stateQueue.add(this.getCurrentState());
     }
 
     /** Actor used to increment a counter based on the event type */
@@ -55,4 +66,7 @@ public class TurnstileData extends AbstractStateTableData {
 
     /** Returns the current ticket count */
     public int getTicketCount() { return ticketCount; }
+
+    /** Returns the state queue to track state transitions for testing purposes */
+    private Queue<String> getStateQueue() { return stateQueue; }
 }

--- a/src/test/java/com/worthent/foundation/util/state/examples/turnstyle/TurnstileStateTable.java
+++ b/src/test/java/com/worthent/foundation/util/state/examples/turnstyle/TurnstileStateTable.java
@@ -1,0 +1,86 @@
+package com.worthent.foundation.util.state.examples.turnstyle;
+
+import com.worthent.foundation.util.state.StateEvent;
+import com.worthent.foundation.util.state.StateEvents;
+import com.worthent.foundation.util.state.StateTable;
+import com.worthent.foundation.util.state.def.StateDef;
+import com.worthent.foundation.util.state.def.StateTransitionDefs;
+import com.worthent.foundation.util.state.impl.StateTableBuilderImpl;
+
+import java.util.Queue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TurnstileStateTable {
+
+    static final StateEvent ON_EVENT = StateEvents.enumeratedStateEvent(TurnstileEventType.ON);
+    static final StateEvent PUSH_EVENT = StateEvents.enumeratedStateEvent(TurnstileEventType.PUSH);
+    static final StateEvent TICKET_EVENT = StateEvents.enumeratedStateEvent(TurnstileEventType.TICKET);
+    static final StateEvent OFF_EVENT = StateEvents.enumeratedStateEvent(TurnstileEventType.OFF);
+
+    /** State table data */
+    private TurnstileData stateTableData;
+
+    /** State table representing a turnstile like you find in amusement parks */
+    private final StateTable<TurnstileData, StateEvent> turnstileStateTable;
+
+    TurnstileStateTable(final Queue<String> stateQueue) {
+        this.turnstileStateTable =
+                new StateTableBuilderImpl<TurnstileData, StateEvent>()
+                        .withStateTableDefinition()
+                        .setName("Turnstile")
+                        .usingActorsInClass(TurnstileData.class)
+                        .withState(TurnstileStates.OFF)
+                            .transitionOnEvent(TurnstileEventType.ON).toState(TurnstileStates.LOCKED).endTransition()
+                            .withDefaultEventHandler().toState(StateDef.STAY_IN_STATE).endTransition()
+                            .endState()
+                        .withState(TurnstileStates.LOCKED)
+                            .transitionOnEvent(TurnstileEventType.TICKET)
+                                .toState(TurnstileStates.UNLOCKED)
+                                .withActorsByName(TurnstileData.INCREMENT_COUNT)
+                                .endTransition()
+                            .transitionOnEvent(TurnstileEventType.PUSH).toState(StateDef.STAY_IN_STATE).endTransition()
+                            .transitionOnEvent(TurnstileEventType.OFF).toState(TurnstileStates.OFF).endTransition()
+                            .withDefaultEventHandler(StateTransitionDefs.getUnexpectedEventDefaultTransition())
+                            .endState()
+                        .withState(TurnstileStates.UNLOCKED)
+                            .transitionOnEvent(TurnstileEventType.TICKET).toState(StateDef.STAY_IN_STATE).endTransition()
+                            .transitionOnEvent(TurnstileEventType.PUSH)
+                                .toState(TurnstileStates.LOCKED)
+                                .withActorsByName(TurnstileData.INCREMENT_COUNT)
+                                .endTransition()
+                            .transitionOnEvent(TurnstileEventType.OFF).toState(TurnstileStates.OFF).endTransition()
+                            .withDefaultEventHandler(StateTransitionDefs.getUnexpectedEventDefaultTransition())
+                            .endState()
+                        .endDefinition()
+                        .withStateTableDataManager()
+                            .withInitializer(() -> stateTableData = new TurnstileData(stateQueue))
+                            .withDataGetter((e) -> new TurnstileData(stateTableData))
+                            .withDataSetter((e, updatedData) -> stateTableData.set(updatedData))
+                            .endDataManager()
+                        .build();
+    }
+
+    public TurnstileData getStateTableData() {
+        return stateTableData;
+    }
+
+    public StateTable<TurnstileData, StateEvent> getTurnstileStateTable() {
+        return turnstileStateTable;
+    }
+
+    static void assertExpectedState(final Queue<String> stateQueue, final TurnstileStates expectedState) {
+        final String actualState = stateQueue.remove();
+        assertThat(actualState).isEqualToIgnoringCase(expectedState.name());
+    }
+
+    static void assertExpectedState(
+            final BlockingQueue<String> stateQueue,
+            final TurnstileStates expectedState) throws InterruptedException {
+        final String actualState = stateQueue.poll(2, TimeUnit.SECONDS);
+        assertThat(actualState).isEqualToIgnoringCase(expectedState.name());
+    }
+
+}

--- a/src/test/java/com/worthent/foundation/util/state/examples/xml/SaxEventAdapterTest.java
+++ b/src/test/java/com/worthent/foundation/util/state/examples/xml/SaxEventAdapterTest.java
@@ -56,16 +56,13 @@ public class SaxEventAdapterTest {
     /** The list of purchase orders received */
     private List<PurchaseOrderData> purchaseOrders;
 
-    /** The state table control object */
-    private StateTableControl<XmlEvent> stateTableControl;
-
     /** The class being tested here */
     private SaxEventAdapter saxEventAdapter;
 
     @Before
-    public void setup() throws Exception {
+    public void setup() {
         purchaseOrders = new LinkedList<>();
-        stateTableControl = new XmlObjectBuilderAdapter(
+        final StateTableControl<XmlEvent> stateTableControl = new XmlObjectBuilderAdapter(
                 new ObjectConstructionController<>(PurchaseOrderData.class, purchaseOrders::add));
         saxEventAdapter = new SaxEventAdapter(stateTableControl);
     }

--- a/src/test/java/com/worthent/foundation/util/state/impl/StateEventWithDataMapImplTest.java
+++ b/src/test/java/com/worthent/foundation/util/state/impl/StateEventWithDataMapImplTest.java
@@ -1,0 +1,80 @@
+package com.worthent.foundation.util.state.impl;
+
+import com.worthent.foundation.util.annotation.NotNull;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static com.worthent.foundation.util.condition.Preconditions.checkNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests the StateEventBuilder and the StateEventWithDataMap implementations to make sure the classes can be extended
+ * and work properly.
+ *
+ * @author Erik K. Worth
+ */
+public class StateEventWithDataMapImplTest {
+
+    private static final String TEST_SESSION_ID = "test-session-id";
+    private static final String TEST_EVENT_PARAM_VALUE = "test-event-param-value";
+
+    /** Extend the basic StateEventWithDataMap with a required field */
+    private final class TestStateEvent extends StateEventWithDataMapImpl {
+
+        private static final String EVENT_1 = "event-1";
+        private static final String EVENT_2 = "event-2";
+
+        private static final String PARAM_KEY_1 = "param-key-1";
+
+        /** Every event must have this field */
+        private final String sessionId;
+
+        private TestStateEvent(
+                @NotNull final String eventName,
+                @NotNull final String sessionId,
+                @NotNull final Map<String, Object> eventData) {
+            super(eventName, eventData);
+            this.sessionId = checkNotNull(sessionId, "sessionId must not be null");
+        }
+
+        @NotNull
+        private String getSessionId() {
+            return sessionId;
+        }
+    }
+
+    /** Extend the basic StateEventBuilder to build a TestStateEvent event */
+    private final class TestStateEventBuilder extends StateEventBuilderImpl<TestStateEvent> {
+
+        /** Every event must have this field */
+        private final String sessionId;
+
+        /**
+         * Construct with the event name
+         *
+         * @param eventName the identifier for the event
+         */
+        public TestStateEventBuilder(@NotNull final String eventName, @NotNull final String sessionId) {
+            super(eventName);
+            this.sessionId = checkNotNull(sessionId, "sessionId must not be null");
+        }
+
+        @Override
+        @NotNull
+        public TestStateEvent build() {
+            return new TestStateEvent(getName(), sessionId, getEventData());
+        }
+    }
+
+    @Test
+    public void build_withValidParametersAndConfirm() {
+        final TestStateEvent event = new TestStateEventBuilder(TestStateEvent.EVENT_1, TEST_SESSION_ID)
+                .withEventData(TestStateEvent.PARAM_KEY_1, TEST_EVENT_PARAM_VALUE)
+                .build();
+        assertThat(event.getName()).isEqualTo(TestStateEvent.EVENT_1);
+        assertThat(event.getSessionId()).isEqualTo(TEST_SESSION_ID);
+        final String param1 = event.getRequiredEventData(TestStateEvent.PARAM_KEY_1);
+        assertThat(param1).isEqualTo(TEST_EVENT_PARAM_VALUE);
+    }
+}


### PR DESCRIPTION
The state table now includes a number of enhancements:

* There is a function on the TransitionContext called getPotentialTargetStates that returns the set of potential states to which the state table will transition from the current state (from state) for the event being processed.

* The StateEventBuilder and its implementation are enhanced to make it possible to extend the classes.

* The state table definition now allows enumerated types for event and state identifies in addition to Strings.  You no long need to add the .name() to the enumerated values when defining the state table.

* There is now an implementation of the State Table Control that uses a single thread consuming from a blocking queue to feed events into the state table in the order received.  This is the SingleThreadConsumerStateTableControl class mentioned in the documentation.

* The AbstractStateTableData methods are no longer final so that they can be mocked in tests.